### PR TITLE
Return the correct value out of dbd_st_fetch if an exception is thrown

### DIFF
--- a/dbdimp.cpp
+++ b/dbdimp.cpp
@@ -152,6 +152,7 @@ AV* dbd_st_fetch(SV *sth, imp_sth_t* imp_sth)
         }
     } catch (NuoDB::SQLException& xcp) {
         do_error(sth, xcp.getSqlcode(), xcp.getText());
+        return Nullav;
     }
 
     av = DBIc_DBISTATE(imp_sth)->get_fbav(imp_sth);


### PR DESCRIPTION
If an exception is thrown during fetching the result set, total mayhem occurs.